### PR TITLE
feat: static libextism-cpp / pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,10 @@ link_directories(/opt/homebrew/lib)
 
 # extism-cpp library
 project(extism-cpp VERSION 1.0.0 DESCRIPTION "C++ bindings for libextism")
-add_library(extism-cpp SHARED src/manifest.cpp src/current_plugin.cpp src/plugin.cpp src/function.cpp src/extism.cpp)
+set(extism-cpp-srcs src/manifest.cpp src/current_plugin.cpp src/plugin.cpp src/function.cpp src/extism.cpp)
+
+# SHARED
+add_library(extism-cpp SHARED ${extism-cpp-srcs})
 set_target_properties(extism-cpp PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(extism-cpp PROPERTIES PUBLIC_HEADER src/extism.hpp)
 target_include_directories(extism-cpp PUBLIC src)
@@ -15,7 +18,15 @@ target_link_libraries(extism-cpp PUBLIC extism jsoncpp)
 set_target_properties(extism-cpp
   PROPERTIES NO_SONAME 1
 )
-install(TARGETS extism-cpp
+
+# STATIC
+add_library(extism-cpp-static STATIC ${extism-cpp-srcs})
+set_target_properties(extism-cpp-static PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(extism-cpp-static PROPERTIES PUBLIC_HEADER src/extism.hpp)
+target_include_directories(extism-cpp-static PUBLIC src)
+target_link_libraries(extism-cpp-static PUBLIC extism jsoncpp)
+
+install(TARGETS extism-cpp extism-cpp-static
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,17 +18,26 @@ target_link_libraries(extism-cpp PUBLIC extism jsoncpp)
 set_target_properties(extism-cpp
   PROPERTIES NO_SONAME 1
 )
+configure_file(extism-cpp.pc.in extism-cpp.pc @ONLY)
 
 # STATIC
 add_library(extism-cpp-static STATIC ${extism-cpp-srcs})
+set_target_properties(extism-cpp-static PROPERTIES OUTPUT_NAME extism-cpp)
 set_target_properties(extism-cpp-static PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(extism-cpp-static PROPERTIES PUBLIC_HEADER src/extism.hpp)
 target_include_directories(extism-cpp-static PUBLIC src)
-target_link_libraries(extism-cpp-static PUBLIC extism jsoncpp)
+target_link_libraries(extism-cpp-static PUBLIC libextism.a jsoncpp)
+configure_file(extism-cpp-static.pc.in extism-cpp-static.pc @ONLY)
 
-install(TARGETS extism-cpp extism-cpp-static
+include(GNUInstallDirs)
+install(TARGETS extism-cpp
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(TARGETS extism-cpp-static
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/extism-cpp.pc ${CMAKE_CURRENT_BINARY_DIR}/extism-cpp-static.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # Example
 add_executable(
@@ -38,6 +47,16 @@ add_executable(
 target_link_libraries(
   example
   extism-cpp
+)
+
+# Static-ish example
+add_executable(
+  example-static
+  example.cpp
+)
+target_link_libraries(
+  example-static
+  extism-cpp-static
 )
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ C++ Host SDK for Extism
   - Debian: `sudo apt install libjsoncpp-dev`
   - macOS: `brew install jsoncpp`
 
+If you wish to link libextism-cpp with its deps statically, to make a binary
+with only system deps, instead of installing `jsoncpp` from your system
+package manager, you must build and install it from source. This is needed to
+get the static library `libjsoncpp.a`.
+
+```shell
+git clone https://github.com/open-source-parsers/jsoncpp
+cd jsoncpp
+cmake -B build && cmake --build build -j
+make -C build install
+```
+
 ## Building
 
 ```shell
@@ -38,3 +50,16 @@ After building, run the following from the build directory:
 $ sudo make install
 ```
 
+## Usage
+
+After installing, `pkg-config` may be used to get needed linking flags.
+
+### Dynamic
+```shell
+$ pkg-config --libs extism-cpp
+```
+
+### Static
+```shell
+$ pkg-config --static --libs extism-cpp-static
+```

--- a/extism-cpp-static.pc.in
+++ b/extism-cpp-static.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+Version: @PROJECT_VERSION@
+Name: Extism cpp-sdk
+Description: C++ Host SDK for Extism
+Requires.private: extism-static
+Libs: -L${libdir} -l:libextism-cpp.a -l:libjsoncpp.a
+Cflags: -I${includedir}

--- a/extism-cpp.pc.in
+++ b/extism-cpp.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+Version: @PROJECT_VERSION@
+Name: Extism cpp-sdk
+Description: C++ Host SDK for Extism
+Requires.private: extism
+Libs: -L${libdir} -lextism-cpp -ljsoncpp
+Cflags: -I${includedir}


### PR DESCRIPTION
The Extism cpp host sdk may now be linked with its deps (except for system deps) statically.

```bash
pkg-config --static --libs extism-cpp-static
-L/usr/local/lib -l:libextism-cpp.a -l:libjsoncpp.a -l:libextism.a -lm
g++ -o example example.cpp `pkg-config --static --libs extism-cpp-static`
ldd example
        linux-vdso.so.1 (0x00007ffc54dcd000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007efc59000000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007efc59319000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007efc592f9000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007efc58c00000)
        /lib64/ld-linux-x86-64.so.2 (0x00007efc5aba2000)
```

`README.md` is updated with linking instructions.