### PR TITLE
fix: include deps as private in pkg-config

### DIFF
--- a/extism-cpp-static.pc.in
+++ b/extism-cpp-static.pc.in
@@ -6,5 +6,6 @@ Version: @PROJECT_VERSION@
 Name: Extism cpp-sdk
 Description: C++ Host SDK for Extism
 Requires.private: extism-static
-Libs: -L${libdir} -l:libextism-cpp.a -l:libjsoncpp.a
+Libs: -L${libdir} -l:libextism-cpp.a
+Libs.private: -l:libjsoncpp.a
 Cflags: -I${includedir}

--- a/extism-cpp.pc.in
+++ b/extism-cpp.pc.in
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 Version: @PROJECT_VERSION@
 Name: Extism cpp-sdk
 Description: C++ Host SDK for Extism
-Requires.private: extism
-Libs: -L${libdir} -lextism-cpp -ljsoncpp
+Requires.private: extism jsoncpp
+Libs: -L${libdir} -lextism-cpp
 Cflags: -I${includedir}


### PR DESCRIPTION
They do not need to be exposed to the application so I think this is best practice. The dynamic pkg-config also able to use the jsoncpp package as a dep instead of adding its linking flags manually. 