### PR TITLE
feat/fix/chore: various improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ set_target_properties(extism-cpp PROPERTIES PUBLIC_HEADER src/extism.hpp)
 target_include_directories(extism-cpp PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
-target_link_libraries(extism-cpp PUBLIC extism-shared jsoncpp_lib)
+target_link_libraries(extism-cpp PUBLIC extism-shared)
+target_link_libraries(extism-cpp PRIVATE jsoncpp_lib)
 set_target_properties(extism-cpp
   PROPERTIES NO_SONAME 1
 )
@@ -68,10 +69,10 @@ target_include_directories(extism-cpp-static PUBLIC
 )
 target_link_libraries(extism-cpp-static PUBLIC extism-static)
 if(TARGET jsoncpp_static)
-  target_link_libraries(extism-cpp-static PUBLIC jsoncpp_static)
+  target_link_libraries(extism-cpp-static PRIVATE jsoncpp_static)
 else()
   message(WARNING "jsoncpp_static not found, linking jsoncpp_lib instead")
-  target_link_libraries(extism-cpp-static PUBLIC jsoncpp_lib)
+  target_link_libraries(extism-cpp-static PRIVATE jsoncpp_lib)
 endif()
 configure_file(extism-cpp-static.pc.in extism-cpp-static.pc @ONLY)
 list(APPEND CMAKE_TARGETS extism-cpp-static)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 include_guard(GLOBAL)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 # extism-cpp library
 project(extism-cpp VERSION 1.0.0 DESCRIPTION "C++ bindings for libextism")

--- a/example.cpp
+++ b/example.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
   Plugin plugin(wasm, true, functions);
 
   const char *input = argc > 1 ? argv[1] : "this is a test";
-  ExtismSize length = strlen(input);
+  size_t length = strlen(input);
 
   extism::Buffer output = plugin.call("count_vowels", (uint8_t *)input, length);
   std::cout << (char *)output.data << std::endl;

--- a/src/current_plugin.cpp
+++ b/src/current_plugin.cpp
@@ -1,5 +1,6 @@
 
 #include "extism.hpp"
+#include <cstring>
 
 namespace extism {
 
@@ -33,12 +34,6 @@ void CurrentPlugin::output(const uint8_t *bytes, size_t len,
     memcpy(this->memory() + offs, bytes, len);
     this->outputs[index].v.i64 = offs;
   }
-}
-
-void CurrentPlugin::output(const Json::Value &&v, size_t index) const {
-  Json::FastWriter writer;
-  const std::string s = writer.write(v);
-  this->output(s, index);
 }
 
 uint8_t *CurrentPlugin::inputBytes(size_t *length, size_t index) const {

--- a/src/current_plugin.cpp
+++ b/src/current_plugin.cpp
@@ -3,44 +3,45 @@
 
 namespace extism {
 
-uint8_t *CurrentPlugin::memory() {
+uint8_t *CurrentPlugin::memory() const {
   return extism_current_plugin_memory(this->pointer);
 }
-uint8_t *CurrentPlugin::memory(MemoryHandle offs) {
+uint8_t *CurrentPlugin::memory(MemoryHandle offs) const {
   return this->memory() + offs;
 }
 
-ExtismSize CurrentPlugin::memoryLength(MemoryHandle offs) {
+ExtismSize CurrentPlugin::memoryLength(MemoryHandle offs) const {
   return extism_current_plugin_memory_length(this->pointer, offs);
 }
 
-MemoryHandle CurrentPlugin::memoryAlloc(ExtismSize size) {
+MemoryHandle CurrentPlugin::memoryAlloc(ExtismSize size) const {
   return extism_current_plugin_memory_alloc(this->pointer, size);
 }
 
-void CurrentPlugin::memoryFree(MemoryHandle handle) {
+void CurrentPlugin::memoryFree(MemoryHandle handle) const {
   extism_current_plugin_memory_free(this->pointer, handle);
 }
 
-void CurrentPlugin::output(const std::string &s, size_t index) {
+void CurrentPlugin::output(const std::string &s, size_t index) const {
   this->output((const uint8_t *)s.c_str(), s.size(), index);
 }
 
-void CurrentPlugin::output(const uint8_t *bytes, size_t len, size_t index) {
-  if (index < this->nInputs) {
+void CurrentPlugin::output(const uint8_t *bytes, size_t len,
+                           size_t index) const {
+  if (index < this->nOutputs) {
     auto offs = this->memoryAlloc(len);
     memcpy(this->memory() + offs, bytes, len);
     this->outputs[index].v.i64 = offs;
   }
 }
 
-void CurrentPlugin::output(const Json::Value &&v, size_t index) {
+void CurrentPlugin::output(const Json::Value &&v, size_t index) const {
   Json::FastWriter writer;
   const std::string s = writer.write(v);
   this->output(s, index);
 }
 
-uint8_t *CurrentPlugin::inputBytes(size_t *length, size_t index) {
+uint8_t *CurrentPlugin::inputBytes(size_t *length, size_t index) const {
   if (index >= this->nInputs) {
     return nullptr;
   }
@@ -54,19 +55,19 @@ uint8_t *CurrentPlugin::inputBytes(size_t *length, size_t index) {
   return this->memory() + inp.v.i64;
 }
 
-Buffer CurrentPlugin::inputBuffer(size_t index) {
+Buffer CurrentPlugin::inputBuffer(size_t index) const {
   size_t length = 0;
   auto ptr = inputBytes(&length, index);
   return Buffer(ptr, length);
 }
 
-std::string CurrentPlugin::inputString(size_t index) {
+std::string CurrentPlugin::inputString(size_t index) const {
   size_t length = 0;
   char *buf = (char *)this->inputBytes(&length, index);
   return std::string(buf, length);
 }
 
-const Val &CurrentPlugin::inputVal(size_t index) {
+const Val &CurrentPlugin::inputVal(size_t index) const {
   if (index >= nInputs) {
     throw Error("Input out of bounds");
   }
@@ -74,7 +75,7 @@ const Val &CurrentPlugin::inputVal(size_t index) {
   return this->inputs[index];
 }
 
-Val &CurrentPlugin::outputVal(size_t index) {
+Val &CurrentPlugin::outputVal(size_t index) const {
   if (index >= nOutputs) {
     throw Error("Output out of bounds");
   }

--- a/src/extism.cpp
+++ b/src/extism.cpp
@@ -8,5 +8,5 @@ inline bool setLogFile(const char *filename, const char *level) {
 }
 
 // Get libextism version
-inline std::string version() { return std::string(extism_version()); }
+inline std::string_view version() { return extism_version(); }
 }; // namespace extism

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -103,9 +103,9 @@ public:
 
 class Buffer {
 public:
-  Buffer(const uint8_t *ptr, ExtismSize len) : data(ptr), length(len) {}
+  Buffer(const uint8_t *ptr, size_t len) : data(ptr), length(len) {}
   const uint8_t *const data;
-  const ExtismSize length;
+  const size_t length;
 
   std::string string() const { return static_cast<std::string>(*this); }
 
@@ -203,7 +203,7 @@ public:
   };
 
   // Create a new plugin
-  Plugin(const uint8_t *wasm, ExtismSize length, bool withWasi = false,
+  Plugin(const uint8_t *wasm, size_t length, bool withWasi = false,
          std::vector<Function> functions = std::vector<Function>());
 
   Plugin(const std::string &str, bool withWasi = false,
@@ -225,8 +225,7 @@ public:
   void config(const std::string &json);
 
   // Call a plugin
-  Buffer call(const char *func, const uint8_t *input,
-              ExtismSize inputLength) const;
+  Buffer call(const char *func, const uint8_t *input, size_t inputLength) const;
 
   // Call a plugin function with std::vector<uint8_t> input
   Buffer call(const char *func, const std::vector<uint8_t> &input) const;
@@ -236,7 +235,7 @@ public:
 
   // Call a plugin
   Buffer call(const std::string &func, const uint8_t *input,
-              ExtismSize inputLength) const;
+              size_t inputLength) const;
 
   // Call a plugin function with std::vector<uint8_t> input
   Buffer call(const std::string &func, const std::vector<uint8_t> &input) const;

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -6,6 +6,7 @@
 #include <json/json.h>
 #include <map>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -20,22 +21,6 @@ public:
 
 typedef std::map<std::string, std::string> Config;
 
-template <typename T> class ManifestKey {
-  bool is_set;
-
-public:
-  T value;
-  ManifestKey(T x, bool is_set = false) : is_set(is_set), value(std::move(x)) {}
-  ManifestKey() : is_set(false) {}
-
-  void set(T x) {
-    value = std::move(x);
-    is_set = true;
-  }
-
-  bool empty() const { return !is_set; }
-};
-
 enum WasmSource { WasmSourcePath, WasmSourceURL, WasmSourceBytes };
 
 class Wasm {
@@ -45,7 +30,7 @@ class Wasm {
   std::map<std::string, std::string> httpHeaders;
 
   // TODO: add base64 encoded raw data
-  ManifestKey<std::string> _hash;
+  std::string _hash;
 
 public:
   Wasm(WasmSource source, std::string ref, std::string hash = std::string())
@@ -74,11 +59,11 @@ class Manifest {
 public:
   Config config;
   std::vector<Wasm> wasm;
-  ManifestKey<std::vector<std::string>> allowedHosts;
-  ManifestKey<std::map<std::string, std::string>> allowedPaths;
-  ManifestKey<uint64_t> timeout;
+  std::vector<std::string> allowedHosts;
+  std::map<std::string, std::string> allowedPaths;
+  std::optional<uint64_t> timeout;
 
-  Manifest() : timeout(0, false) {}
+  Manifest() {}
 
   // Create manifest with a single Wasm from a path
   static Manifest wasmPath(std::string s, std::string hash = std::string());

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -199,7 +199,7 @@ public:
 
   public:
     CancelHandle(const ExtismCancelHandle *x) : handle(x){};
-    bool cancel() { return extism_plugin_cancel(this->handle); }
+    bool cancel();
   };
 
   // Create a new plugin

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -179,6 +179,12 @@ public:
 class Plugin {
   std::vector<Function> functions;
 
+  struct PluginDeleter {
+    void operator()(ExtismPlugin *) const;
+  };
+  using unique_plugin = std::unique_ptr<ExtismPlugin, PluginDeleter>;
+  unique_plugin plugin;
+
 public:
   class CancelHandle {
     const ExtismCancelHandle *handle;
@@ -188,7 +194,6 @@ public:
     bool cancel() { return extism_plugin_cancel(this->handle); }
   };
 
-  ExtismPlugin *plugin;
   // Create a new plugin
   Plugin(const uint8_t *wasm, ExtismSize length, bool withWasi = false,
          std::vector<Function> functions = std::vector<Function>());
@@ -204,8 +209,6 @@ public:
   // Create a new plugin from Manifest
   Plugin(const Manifest &manifest, bool withWasi = false,
          std::vector<Function> functions = {});
-
-  ~Plugin();
 
   void config(const Config &data);
 
@@ -230,6 +233,9 @@ public:
   // Reset the Extism runtime, this will invalidate all allocated memory
   // returns true if it succeeded
   bool reset() const;
+
+  // Get a ptr to the plugin that can be passed to the c api
+  ExtismPlugin *get() const { return plugin.get(); }
 };
 
 // Set global log file for plugins

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -37,20 +37,20 @@ public:
       : source(source), ref(std::move(ref)), _hash(std::move(hash)) {}
 
   // Create Wasm pointing to a path
-  static Wasm path(std::string s, std::string hash = std::string()) {
-    return Wasm(WasmSourcePath, std::move(s), std::move(hash));
-  }
+  static Wasm path(std::string s, std::string hash = std::string());
 
   // Create Wasm pointing to a URL
   static Wasm url(std::string s, std::string hash = std::string(),
                   std::string method = "GET",
-                  std::map<std::string, std::string> headers =
-                      std::map<std::string, std::string>()) {
-    auto wasm = Wasm(WasmSourceURL, std::move(s), std::move(hash));
-    wasm.httpMethod = std::move(method);
-    wasm.httpHeaders = std::move(headers);
-    return wasm;
-  }
+                  std::map<std::string, std::string> headers = {});
+
+  // Create Wasm from bytes of a module
+  static Wasm bytes(const uint8_t *data, const size_t len,
+                    std::string hash = std::string());
+
+  // Create Wasm from bytes of a module
+  static Wasm bytes(const std::vector<uint8_t> &data,
+                    std::string hash = std::string());
 
   Json::Value json() const;
 };
@@ -71,6 +71,11 @@ public:
   // Create manifest with a single Wasm from a URL
   static Manifest wasmURL(std::string s, std::string hash = std::string());
 
+  // Create manifest from Wasm data
+  static Manifest wasmBytes(const uint8_t *data, const size_t len,
+                            std::string hash = std::string());
+  static Manifest wasmBytes(const std::vector<uint8_t> &data, std::string hash);
+
   std::string json() const;
 
   // Add Wasm from path
@@ -78,6 +83,11 @@ public:
 
   // Add Wasm from URL
   void addWasmURL(std::string u, std::string hash = std::string());
+
+  // add Wasm from bytes
+  void addWasmBytes(const uint8_t *data, const size_t len,
+                    std::string hash = std::string());
+  void addWasmBytes(const std::vector<uint8_t> &data, std::string hash);
 
   // Add host to allowed hosts
   void allowHost(std::string host);

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -110,8 +110,8 @@ public:
 class Buffer {
 public:
   Buffer(const uint8_t *ptr, ExtismSize len) : data(ptr), length(len) {}
-  const uint8_t *data;
-  ExtismSize length;
+  const uint8_t *const data;
+  const ExtismSize length;
 
   std::string string() const { return static_cast<std::string>(*this); }
 

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -243,6 +243,10 @@ public:
 
   // Returns true if the specified function exists
   bool functionExists(const std::string &func) const;
+
+  // Reset the Extism runtime, this will invalidate all allocated memory
+  // returns true if it succeeded
+  bool reset() const;
 };
 
 // Set global log file for plugins

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -176,15 +176,13 @@ private:
   UserData userData;
 
 public:
-  Function(std::string name, const std::vector<ValType> inputs,
-           const std::vector<ValType> outputs, FunctionType f,
+  Function(std::string name, const std::vector<ValType> &inputs,
+           const std::vector<ValType> &outputs, FunctionType f,
            void *userData = NULL, std::function<void(void *)> free = nullptr);
 
-  Function(std::string ns, std::string name, const std::vector<ValType> inputs,
-           const std::vector<ValType> outputs, FunctionType f,
-           void *userData = NULL, std::function<void(void *)> free = nullptr) {
-    this->setNamespace(ns);
-  }
+  Function(std::string ns, std::string name, const std::vector<ValType> &inputs,
+           const std::vector<ValType> &outputs, FunctionType f,
+           void *userData = NULL, std::function<void(void *)> free = nullptr);
 
   void setNamespace(std::string s) const;
 

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace extism {
@@ -107,14 +108,16 @@ public:
   const uint8_t *const data;
   const size_t length;
 
-  std::string string() const { return static_cast<std::string>(*this); }
+  std::string_view string() const {
+    return static_cast<std::string_view>(*this);
+  }
 
   std::vector<uint8_t> vector() const {
     return static_cast<std::vector<uint8_t>>(*this);
   }
 
-  operator std::string() const {
-    return std::string(reinterpret_cast<const char *>(data), length);
+  operator std::string_view() const {
+    return std::string_view(reinterpret_cast<const char *>(data), length);
   }
   operator std::vector<uint8_t>() const {
     return std::vector<uint8_t>(data, data + length);
@@ -144,11 +147,11 @@ public:
   ExtismSize memoryLength(MemoryHandle offs) const;
   MemoryHandle memoryAlloc(ExtismSize size) const;
   void memoryFree(MemoryHandle handle) const;
-  void output(const std::string &s, size_t index = 0) const;
-  void output(const uint8_t *bytes, size_t len, size_t index = 0) const;
+  bool output(std::string_view s, size_t index = 0) const;
+  bool output(const uint8_t *bytes, size_t len, size_t index = 0) const;
   uint8_t *inputBytes(size_t *length = nullptr, size_t index = 0) const;
   Buffer inputBuffer(size_t index = 0) const;
-  std::string inputString(size_t index = 0) const;
+  std::string_view inputStringView(size_t index = 0) const;
   const Val &inputVal(size_t index) const;
   Val &outputVal(size_t index) const;
 };
@@ -173,11 +176,12 @@ public:
            const std::vector<ValType> &outputs, FunctionType f,
            void *userData = NULL, std::function<void(void *)> free = nullptr);
 
-  Function(std::string ns, std::string name, const std::vector<ValType> &inputs,
+  Function(const std::string &ns, std::string name,
+           const std::vector<ValType> &inputs,
            const std::vector<ValType> &outputs, FunctionType f,
            void *userData = NULL, std::function<void(void *)> free = nullptr);
 
-  void setNamespace(std::string s) const;
+  void setNamespace(const std::string &s) const;
 
   Function(const Function &f);
 
@@ -206,7 +210,7 @@ public:
   Plugin(const uint8_t *wasm, size_t length, bool withWasi = false,
          std::vector<Function> functions = std::vector<Function>());
 
-  Plugin(const std::string &str, bool withWasi = false,
+  Plugin(std::string_view str, bool withWasi = false,
          std::vector<Function> functions = {});
 
   Plugin(const std::vector<uint8_t> &data, bool withWasi = false,
@@ -222,7 +226,7 @@ public:
 
   void config(const char *json, size_t length);
 
-  void config(const std::string &json);
+  void config(std::string_view json);
 
   // Call a plugin
   Buffer call(const char *func, const uint8_t *input, size_t inputLength) const;
@@ -231,7 +235,7 @@ public:
   Buffer call(const char *func, const std::vector<uint8_t> &input) const;
 
   // Call a plugin function with string input
-  Buffer call(const char *func, const std::string &input = std::string()) const;
+  Buffer call(const char *func, std::string_view input = "") const;
 
   // Call a plugin
   Buffer call(const std::string &func, const uint8_t *input,
@@ -241,8 +245,7 @@ public:
   Buffer call(const std::string &func, const std::vector<uint8_t> &input) const;
 
   // Call a plugin function with string input
-  Buffer call(const std::string &func,
-              const std::string &input = std::string()) const;
+  Buffer call(const std::string &func, std::string_view input = "") const;
 
   // Returns true if the specified function exists
   bool functionExists(const char *func) const;
@@ -262,5 +265,5 @@ public:
 inline bool setLogFile(const char *filename, const char *level);
 
 // Get libextism version
-inline std::string version();
+inline std::string_view version();
 } // namespace extism

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -217,6 +217,16 @@ public:
   void config(const std::string &json);
 
   // Call a plugin
+  Buffer call(const char *func, const uint8_t *input,
+              ExtismSize inputLength) const;
+
+  // Call a plugin function with std::vector<uint8_t> input
+  Buffer call(const char *func, const std::vector<uint8_t> &input) const;
+
+  // Call a plugin function with string input
+  Buffer call(const char *func, const std::string &input = std::string()) const;
+
+  // Call a plugin
   Buffer call(const std::string &func, const uint8_t *input,
               ExtismSize inputLength) const;
 
@@ -226,6 +236,9 @@ public:
   // Call a plugin function with string input
   Buffer call(const std::string &func,
               const std::string &input = std::string()) const;
+
+  // Returns true if the specified function exists
+  bool functionExists(const char *func) const;
 
   // Returns true if the specified function exists
   bool functionExists(const std::string &func) const;

--- a/src/extism.hpp
+++ b/src/extism.hpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <extism.h>
 #include <functional>
-#include <json/json.h>
 #include <map>
 #include <memory>
 #include <optional>
@@ -52,7 +51,7 @@ public:
   static Wasm bytes(const std::vector<uint8_t> &data,
                     std::string hash = std::string());
 
-  Json::Value json() const;
+  friend class Serializer;
 };
 
 class Manifest {
@@ -147,7 +146,6 @@ public:
   void memoryFree(MemoryHandle handle) const;
   void output(const std::string &s, size_t index = 0) const;
   void output(const uint8_t *bytes, size_t len, size_t index = 0) const;
-  void output(const Json::Value &&v, size_t index = 0) const;
   uint8_t *inputBytes(size_t *length = nullptr, size_t index = 0) const;
   Buffer inputBuffer(size_t index = 0) const;
   std::string inputString(size_t index = 0) const;

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -2,8 +2,8 @@
 
 namespace extism {
 static void functionCallback(ExtismCurrentPlugin *plugin,
-                             const ExtismVal *inputs, size_t n_inputs,
-                             ExtismVal *outputs, size_t n_outputs,
+                             const ExtismVal *inputs, ExtismSize n_inputs,
+                             ExtismVal *outputs, ExtismSize n_outputs,
                              void *user_data) {
   Function::UserData *data = static_cast<Function::UserData *>(user_data);
   data->func(CurrentPlugin(plugin, inputs, n_inputs, outputs, n_outputs),

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -30,12 +30,12 @@ Function::Function(std::string name, const std::vector<ValType> inputs,
   this->func = std::shared_ptr<ExtismFunction>(ptr, extism_function_free);
 }
 
-void Function::setNamespace(std::string s) {
+void Function::setNamespace(std::string s) const {
   extism_function_set_namespace(this->func.get(), s.c_str());
 }
 
 Function::Function(const Function &f) { this->func = f.func; }
 
-ExtismFunction *Function::get() { return this->func.get(); }
+ExtismFunction *Function::get() const { return this->func.get(); }
 
 }; // namespace extism

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -2,8 +2,8 @@
 
 namespace extism {
 static void functionCallback(ExtismCurrentPlugin *plugin,
-                             const ExtismVal *inputs, ExtismSize n_inputs,
-                             ExtismVal *outputs, ExtismSize n_outputs,
+                             const ExtismVal *inputs, size_t n_inputs,
+                             ExtismVal *outputs, size_t n_outputs,
                              void *user_data) {
   Function::UserData *data = static_cast<Function::UserData *>(user_data);
   data->func(CurrentPlugin(plugin, inputs, n_inputs, outputs, n_outputs),

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -30,15 +30,15 @@ Function::Function(std::string name, const std::vector<ValType> &inputs,
   this->func = std::shared_ptr<ExtismFunction>(ptr, extism_function_free);
 }
 
-Function::Function(std::string ns, std::string name,
+Function::Function(const std::string &ns, std::string name,
                    const std::vector<ValType> &inputs,
                    const std::vector<ValType> &outputs, FunctionType f,
                    void *userData, std::function<void(void *)> free)
-    : Function(name, inputs, outputs, f, userData, free) {
-  this->setNamespace(std::move(ns));
+    : Function(std::move(name), inputs, outputs, f, userData, free) {
+  this->setNamespace(ns);
 }
 
-void Function::setNamespace(std::string s) const {
+void Function::setNamespace(const std::string &s) const {
   extism_function_set_namespace(this->func.get(), s.c_str());
 }
 

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -45,7 +45,7 @@ std::string Manifest::json() const {
   return writer.write(doc);
 }
 
-Json::Value Wasm::json() {
+Json::Value Wasm::json() const {
 
   Json::Value doc;
 
@@ -57,7 +57,7 @@ Json::Value Wasm::json() {
     if (!this->httpHeaders.empty()) {
       Json::Value h;
       for (auto k : this->httpHeaders) {
-        h[k.first] = this->httpHeaders[k.second];
+        h[k.first] = k.second;
       }
       doc["headers"] = h;
     }

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -23,7 +23,7 @@ std::string Manifest::json() const {
   if (!this->allowedHosts.empty()) {
     Json::Value h;
 
-    for (auto s : this->allowedHosts.value) {
+    for (auto s : this->allowedHosts) {
       h.append(s);
     }
     doc["allowed_hosts"] = h;
@@ -31,14 +31,14 @@ std::string Manifest::json() const {
 
   if (!this->allowedPaths.empty()) {
     Json::Value h;
-    for (auto k : this->allowedPaths.value) {
+    for (auto k : this->allowedPaths) {
       h[k.first] = k.second;
     }
     doc["allowed_paths"] = h;
   }
 
-  if (!this->timeout.empty()) {
-    doc["timeout_ms"] = Json::Value(this->timeout.value);
+  if (this->timeout.has_value()) {
+    doc["timeout_ms"] = Json::Value(*this->timeout);
   }
 
   Json::FastWriter writer;
@@ -66,7 +66,7 @@ Json::Value Wasm::json() const {
   }
 
   if (!this->_hash.empty()) {
-    doc["hash"] = this->_hash.value;
+    doc["hash"] = this->_hash;
   }
 
   return doc;
@@ -99,22 +99,15 @@ void Manifest::addWasmURL(std::string u, std::string hash) {
 
 // Add host to allowed hosts
 void Manifest::allowHost(std::string host) {
-  if (this->allowedHosts.empty()) {
-    this->allowedHosts.set(std::vector<std::string>{});
-  }
-  this->allowedHosts.value.push_back(host);
+  this->allowedHosts.push_back(host);
 }
 
 // Add path to allowed paths
 void Manifest::allowPath(std::string src, std::string dest) {
-  if (this->allowedPaths.empty()) {
-    this->allowedPaths.set(std::map<std::string, std::string>{});
-  }
-
   if (dest.empty()) {
     dest = src;
   }
-  this->allowedPaths.value[src] = dest;
+  this->allowedPaths[src] = dest;
 }
 
 // Set timeout in milliseconds

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -125,45 +125,16 @@ std::string Manifest::json() const {
   return writer.write(doc);
 }
 
-/*
-Json::Value Wasm::json() const {
-
-  Json::Value doc;
-
-  if (this->source == WasmSourcePath) {
-    doc["path"] = this->ref;
-  } else if (this->source == WasmSourceURL) {
-    doc["url"] = this->ref;
-    doc["method"] = this->httpMethod;
-    if (!this->httpHeaders.empty()) {
-      Json::Value h;
-      for (auto k : this->httpHeaders) {
-        h[k.first] = k.second;
-      }
-      doc["headers"] = h;
-    }
-  } else if (this->source == WasmSourceBytes) {
-    doc["data"] = this->ref;
-  }
-
-  if (!this->_hash.empty()) {
-    doc["hash"] = this->_hash;
-  }
-
-  return doc;
-}
-*/
-
 Manifest Manifest::wasmPath(std::string s, std::string hash) {
   Manifest m;
-  m.addWasmPath(s, hash);
+  m.addWasmPath(std::move(s), std::move(hash));
   return m;
 }
 
 // Create manifest with a single Wasm from a URL
 Manifest Manifest::wasmURL(std::string s, std::string hash) {
   Manifest m;
-  m.addWasmURL(s, hash);
+  m.addWasmURL(std::move(s), std::move(hash));
   return m;
 }
 
@@ -171,45 +142,45 @@ Manifest Manifest::wasmURL(std::string s, std::string hash) {
 Manifest Manifest::wasmBytes(const uint8_t *data, const size_t len,
                              std::string hash) {
   Manifest m;
-  m.addWasmBytes(data, len, hash);
+  m.addWasmBytes(data, len, std::move(hash));
   return m;
 }
 
 Manifest Manifest::wasmBytes(const std::vector<uint8_t> &data,
                              std::string hash) {
   Manifest m;
-  m.addWasmBytes(data, hash);
+  m.addWasmBytes(data, std::move(hash));
   return m;
 }
 
 // Add Wasm from path
 void Manifest::addWasmPath(std::string s, std::string hash) {
-  Wasm w = Wasm::path(s, hash);
-  this->wasm.push_back(w);
+  Wasm w = Wasm::path(std::move(s), std::move(hash));
+  this->wasm.push_back(std::move(w));
 }
 
 // Add Wasm from URL
 void Manifest::addWasmURL(std::string u, std::string hash) {
-  Wasm w = Wasm::url(u, hash);
-  this->wasm.push_back(w);
+  Wasm w = Wasm::url(std::move(u), std::move(hash));
+  this->wasm.push_back(std::move(w));
 }
 
 // add Wasm from bytes
 void Manifest::addWasmBytes(const uint8_t *data, const size_t len,
                             std::string hash) {
-  Wasm w = Wasm::bytes(data, len, hash);
-  this->wasm.push_back(w);
+  Wasm w = Wasm::bytes(data, len, std::move(hash));
+  this->wasm.push_back(std::move(w));
 }
 
 void Manifest::addWasmBytes(const std::vector<uint8_t> &data,
                             std::string hash) {
-  Wasm w = Wasm::bytes(data, hash);
-  this->wasm.push_back(w);
+  Wasm w = Wasm::bytes(data, std::move(hash));
+  this->wasm.push_back(std::move(w));
 }
 
 // Add host to allowed hosts
 void Manifest::allowHost(std::string host) {
-  this->allowedHosts.push_back(host);
+  this->allowedHosts.push_back(std::move(host));
 }
 
 // Add path to allowed paths
@@ -217,13 +188,15 @@ void Manifest::allowPath(std::string src, std::string dest) {
   if (dest.empty()) {
     dest = src;
   }
-  this->allowedPaths[src] = dest;
+  this->allowedPaths[std::move(src)] = std::move(dest);
 }
 
 // Set timeout in milliseconds
 void Manifest::setTimeout(uint64_t ms) { this->timeout = ms; }
 
 // Set config key/value
-void Manifest::setConfig(std::string k, std::string v) { this->config[k] = v; }
+void Manifest::setConfig(std::string k, std::string v) {
+  this->config[std::move(k)] = std::move(v);
+}
 
 }; // namespace extism

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,4 +1,5 @@
 #include "extism.hpp"
+#include <json/json.h>
 
 namespace extism {
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -7,7 +7,7 @@ void extism::Plugin::PluginDeleter::operator()(ExtismPlugin *plugin) const {
   extism_plugin_free(plugin);
 }
 
-Plugin::Plugin(const uint8_t *wasm, ExtismSize length, bool withWasi,
+Plugin::Plugin(const uint8_t *wasm, size_t length, bool withWasi,
                std::vector<Function> functions)
     : functions(std::move(functions)) {
   std::vector<const ExtismFunction *> ptrs;
@@ -74,7 +74,7 @@ void Plugin::config(const std::string &json) {
 
 // Call a plugin
 Buffer Plugin::call(const char *func, const uint8_t *input,
-                    ExtismSize inputLength) const {
+                    size_t inputLength) const {
   int32_t rc = extism_plugin_call(this->plugin.get(), func, input, inputLength);
   if (rc != 0) {
     const char *error = extism_plugin_error(this->plugin.get());
@@ -103,7 +103,7 @@ Buffer Plugin::call(const char *func, const std::string &input) const {
 
 // Call a plugin
 Buffer Plugin::call(const std::string &func, const uint8_t *input,
-                    ExtismSize inputLength) const {
+                    size_t inputLength) const {
   return this->call(func.c_str(), input, inputLength);
 }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -68,10 +68,9 @@ void Plugin::config(const std::string &json) {
 }
 
 // Call a plugin
-Buffer Plugin::call(const std::string &func, const uint8_t *input,
+Buffer Plugin::call(const char *func, const uint8_t *input,
                     ExtismSize inputLength) const {
-  int32_t rc =
-      extism_plugin_call(this->plugin.get(), func.c_str(), input, inputLength);
+  int32_t rc = extism_plugin_call(this->plugin.get(), func, input, inputLength);
   if (rc != 0) {
     const char *error = extism_plugin_error(this->plugin.get());
     if (error == nullptr) {
@@ -87,15 +86,36 @@ Buffer Plugin::call(const std::string &func, const uint8_t *input,
 }
 
 // Call a plugin function with std::vector<uint8_t> input
-Buffer Plugin::call(const std::string &func,
-                    const std::vector<uint8_t> &input) const {
+Buffer Plugin::call(const char *func, const std::vector<uint8_t> &input) const {
   return this->call(func, input.data(), input.size());
 }
 
 // Call a plugin function with string input
-Buffer Plugin::call(const std::string &func, const std::string &input) const {
+Buffer Plugin::call(const char *func, const std::string &input) const {
   return this->call(func, reinterpret_cast<const uint8_t *>(input.c_str()),
                     input.size());
+}
+
+// Call a plugin
+Buffer Plugin::call(const std::string &func, const uint8_t *input,
+                    ExtismSize inputLength) const {
+  return this->call(func.c_str(), input, inputLength);
+}
+
+// Call a plugin function with std::vector<uint8_t> input
+Buffer Plugin::call(const std::string &func,
+                    const std::vector<uint8_t> &input) const {
+  return this->call(func.c_str(), input);
+}
+
+// Call a plugin function with string input
+Buffer Plugin::call(const std::string &func, const std::string &input) const {
+  return this->call(func.c_str(), input);
+}
+
+// Returns true if the specified function exists
+bool Plugin::functionExists(const char *func) const {
+  return extism_plugin_function_exists(this->plugin.get(), func);
 }
 
 // Returns true if the specified function exists

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -25,9 +25,9 @@ Plugin::Plugin(const uint8_t *wasm, size_t length, bool withWasi,
   }
 }
 
-Plugin::Plugin(const std::string &str, bool withWasi,
+Plugin::Plugin(std::string_view str, bool withWasi,
                std::vector<Function> functions)
-    : Plugin(reinterpret_cast<const uint8_t *>(str.c_str()), str.size(),
+    : Plugin(reinterpret_cast<const uint8_t *>(str.data()), str.size(),
              withWasi, std::move(functions)) {}
 
 Plugin::Plugin(const std::vector<uint8_t> &data, bool withWasi,
@@ -41,7 +41,7 @@ Plugin::CancelHandle Plugin::cancelHandle() {
 // Create a new plugin from Manifest
 Plugin::Plugin(const Manifest &manifest, bool withWasi,
                std::vector<Function> functions)
-    : Plugin(manifest.json().c_str(), withWasi, std::move(functions)) {}
+    : Plugin(manifest.json(), withWasi, std::move(functions)) {}
 
 bool Plugin::CancelHandle::cancel() {
   return extism_plugin_cancel(this->handle);
@@ -68,8 +68,8 @@ void Plugin::config(const char *json, size_t length) {
   }
 }
 
-void Plugin::config(const std::string &json) {
-  this->config(json.c_str(), json.size());
+void Plugin::config(std::string_view json) {
+  this->config(json.data(), json.size());
 }
 
 // Call a plugin
@@ -96,8 +96,8 @@ Buffer Plugin::call(const char *func, const std::vector<uint8_t> &input) const {
 }
 
 // Call a plugin function with string input
-Buffer Plugin::call(const char *func, const std::string &input) const {
-  return this->call(func, reinterpret_cast<const uint8_t *>(input.c_str()),
+Buffer Plugin::call(const char *func, std::string_view input) const {
+  return this->call(func, reinterpret_cast<const uint8_t *>(input.data()),
                     input.size());
 }
 
@@ -114,7 +114,7 @@ Buffer Plugin::call(const std::string &func,
 }
 
 // Call a plugin function with string input
-Buffer Plugin::call(const std::string &func, const std::string &input) const {
+Buffer Plugin::call(const std::string &func, std::string_view input) const {
   return this->call(func.c_str(), input);
 }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -43,6 +43,10 @@ Plugin::Plugin(const Manifest &manifest, bool withWasi,
                std::vector<Function> functions)
     : Plugin(manifest.json().c_str(), withWasi, std::move(functions)) {}
 
+bool Plugin::CancelHandle::cancel() {
+  return extism_plugin_cancel(this->handle);
+}
+
 void Plugin::config(const Config &data) {
   Json::Value conf;
 


### PR DESCRIPTION
Resolves https://github.com/extism/cpp-sdk/issues/14

feat:
* add `Plugin::reset`
* implement `WasmSourceBytes`

fix:
* Manifest: serialize header values correctly
* current_plugin - when outputting, check against output range correctly
* Function namespace constructor - actually construct

chore:
* protect various class members
* move non-initializer list constructors out of header
* reduce copying with std::move
* bump to C++ 17
* remove `ManifestKey`, the stl containers and `std::optional` are sufficient
* use `std::unique_ptr` to more safely manage `Plugin`'s `ExtismPlugin` lifetime
* make `std::string` no longer required for plugin calls. The duplication introduced can be removed with `std::string_view` if https://github.com/extism/extism/issues/646 is accepted and implemented
* make jsoncpp a private dependency. This improves build times and makes the cpp-sdk not opinionated about what json library the user uses, if any.
* use `size_t` instead of `ExtismSize` when referring to items in native memory / not using libextism