### PR TITLE
feat: passing wasm as via ptr and len in manifest, revamp extism::Wasm

### DIFF
--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -77,7 +77,7 @@ public:
       } else {
         Json::Value data;
         data["ptr"] = reinterpret_cast<uint64_t>(src);
-        data["len"] = srcSize;
+        data["len"] = static_cast<uint64_t>(srcSize);
         doc["data"] = data;
       }
     }

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -77,7 +77,7 @@ public:
       } else {
         Json::Value data;
         data["ptr"] = reinterpret_cast<uint64_t>(src);
-        data["len"] = reinterpret_cast<uint64_t>(srcSize);
+        data["len"] = srcSize;
         doc["data"] = data;
       }
     }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -41,7 +41,7 @@ Plugin::CancelHandle Plugin::cancelHandle() {
 // Create a new plugin from Manifest
 Plugin::Plugin(const Manifest &manifest, bool withWasi,
                std::vector<Function> functions)
-    : Plugin(manifest.json(), withWasi, std::move(functions)) {}
+    : Plugin(manifest.json(false), withWasi, std::move(functions)) {}
 
 bool Plugin::CancelHandle::cancel() {
   return extism_plugin_cancel(this->handle);


### PR DESCRIPTION
Adding support of https://github.com/extism/extism/pull/657

`Manifest::json` by default is self contained (serialized wasm as base64). Pass `false` to instead get `WasmBytes` encoded as ptr and length.

`WasmBytes` is now much more flexible, it still can store a copy of the wasm, but can also instead use a smart pointer.

Deprecated the `Wasm` constructor using `WasmSource` as `std::variant` is now used to manage the types.

`Manifest` can now be constructed with wasm(s). 
